### PR TITLE
chore: add feature rusoto_rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ categories = ["development-tools::debugging"]
 
 [features]
 default = []
-rusoto = ["rusoto_logs", "rusoto_core"]
+rusoto = ["rusoto_logs/default", "rusoto_core/default"]
+rusoto_rustls = ["rusoto_logs/rustls", "rusoto_core/rustls"]
 awssdk = ["aws-sdk-cloudwatchlogs"]
 
 [dependencies]
@@ -19,8 +20,8 @@ anyhow = "1.0"
 async-trait = "0.1"
 aws-sdk-cloudwatchlogs = { version = "0.31", default-features = false, optional = true }
 chrono = "0.4"
-rusoto_core = { version = "0.48", optional = true }
-rusoto_logs = { version = "0.48", optional = true }
+rusoto_core = { version = "0.48", default-features = false, optional = true }
+rusoto_logs = { version = "0.48", default-features = false, optional = true }
 thiserror = "1.0"
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
@@ -33,9 +34,6 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 
 [dev-dependencies]
 aws-config = "0.56"
-aws-sdk-cloudwatchlogs = { version = "0.31.0" }
-rusoto_core = "0.48.0"
-rusoto_logs = "0.48.0"
 tokio = { version = "1.28.0", features = [
   "rt",
   "rt-multi-thread",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,7 +1,25 @@
 [tasks.lint]
 command = "cargo"
-args = ["clippy", "--all-features"]
-dependencies = ["check:fmt", "check:sort"]
+args = ["clippy"]
+dependencies = [
+    "check:fmt",
+    "check:sort",
+    "lint:rusoto",
+    "lint:rusoto_rustls",
+    "lint:awssdk",
+]
+
+[tasks."lint:rusoto"]
+command = "cargo"
+args = ["clippy", "--no-default-features", "--features", "rusoto"]
+
+[tasks."lint:rusoto_rustls"]
+command = "cargo"
+args = ["clippy", "--no-default-features", "--features", "rusoto_rustls"]
+
+[tasks."lint:awssdk"]
+command = "cargo"
+args = ["clippy", "--no-default-features", "--features", "awssdk"]
 
 [tasks."check:fmt"]
 description = "Check format"
@@ -18,4 +36,23 @@ args = ["sort", "--check"]
 description = "Run nextest"
 install_crate = { crate_name = "cargo-nextest" }
 command = "cargo"
-args = ["nextest", "run", "--all-features"]
+args = ["nextest", "run"]
+dependencies = ["test:rusoto", "test:rusoto_rustls", "test:awssdk"]
+
+[tasks."test:rusoto"]
+command = "cargo"
+args = ["nextest", "run", "--no-default-features", "--features", "rusoto"]
+
+[tasks."test:rusoto_rustls"]
+command = "cargo"
+args = [
+    "nextest",
+    "run",
+    "--no-default-features",
+    "--features",
+    "rusoto_rustls",
+]
+
+[tasks."test:awssdk"]
+command = "cargo"
+args = ["nextest", "run", "--no-default-features", "--features", "awssdk"]

--- a/examples/rusoto.rs
+++ b/examples/rusoto.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "rusoto")]
+#[cfg(any(feature = "rusoto", feature = "rusoto_rustls"))]
 #[tokio::main]
 async fn main() {
     use rusoto_core::Region;
@@ -26,7 +26,7 @@ async fn main() {
     tokio::time::sleep(Duration::from_secs(5)).await;
 }
 
-#[cfg(not(feature = "rusoto"))]
+#[cfg(all(not(feature = "rusoto"), not(feature = "rusoto_rustls")))]
 fn main() {}
 
 #[tracing::instrument()]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "rusoto")]
+#[cfg(any(feature = "rusoto", feature = "rusoto_rustls"))]
 mod rusoto;
 
 #[cfg(feature = "awssdk")]

--- a/src/export.rs
+++ b/src/export.rs
@@ -133,7 +133,7 @@ where
                 }
             }
 
-            let logs = queue.drain(..).collect();
+            let logs = std::mem::take(&mut queue);
 
             if let Err(err) = client.put_logs(config.destination.clone(), logs).await {
                 eprintln!(


### PR DESCRIPTION
## Abstract

- add feature `rusoto_rustls` to use feature `rustls` of rusoto.
- separate task ( test and lint ) defined in `Makefile.toml` to run tests by each features.
- fix clippy warning.
