### PR TITLE
update aws-sdk-cloudwatchlogs version from 0.34 to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2024-02-06
+### Changed
+- update aws-sdk-cloudwatchlogs version from 0.34 to 1
+
 ## [0.1.4] - 2023-10-19
 ### Added
 - add `rusoto_rustls` feature https://github.com/ymgyt/tracing-cloudwatch/pull/24

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-cloudwatch"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 description = "tracing-subscriber layer that sends your application's tracing events(logs) to AWS CloudWatch Logs"
@@ -18,7 +18,7 @@ awssdk = ["aws-sdk-cloudwatchlogs"]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-aws-sdk-cloudwatchlogs = { version = "0.34", default-features = false, optional = true }
+aws-sdk-cloudwatchlogs = { version = "1", default-features = false, optional = true }
 chrono = "0.4"
 rusoto_core = { version = "0.48", default-features = false, optional = true }
 rusoto_logs = { version = "0.48", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-aws-config = "0.56"
+aws-config = "1"
 tokio = { version = "1.28.0", features = [
   "rt",
   "rt-multi-thread",

--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@ We have supported [rusoto](https://github.com/rusoto/rusoto) and the [AWS SDK](h
 
 ## Usage
 
-### With Rusoto
+### With AWS SDK
 
-feature `rusoto` required
+feature `awssdk` required
 
 ```rust
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() {
-    let cw_client = rusoto_logs::CloudWatchLogsClient::new(rusoto_core::Region::ApNortheast1);
+    let config = aws_config::load_from_env().await;
+    let cw_client = aws_sdk_cloudwatchlogs::Client::new(&config);
 
     tracing_subscriber::registry::Registry::default()
         .with(
@@ -34,17 +35,16 @@ async fn main() {
 }
 ```
 
-### With AWS SDK
+### With Rusoto
 
-feature `awssdk` required
+feature `rusoto` required
 
 ```rust
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() {
-    let config = aws_config::load_from_env().await;
-    let cw_client = aws_sdk_cloudwatchlogs::Client::new(&config);
+    let cw_client = rusoto_logs::CloudWatchLogsClient::new(rusoto_core::Region::ApNortheast1);
 
     tracing_subscriber::registry::Registry::default()
         .with(


### PR DESCRIPTION
close https://github.com/ymgyt/tracing-cloudwatch/issues/29
update aws sdk dependency to stable ver 1