### PR TITLE
feat: Support ordering LogEvent's

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 rusoto = ["rusoto_logs/default", "rusoto_core/default"]
 rusoto_rustls = ["rusoto_logs/rustls", "rusoto_core/rustls"]
 awssdk = ["aws-sdk-cloudwatchlogs"]
+ordered_logs = []
 
 [dependencies]
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 
 [dev-dependencies]
 aws-config = "1"
+insta = "1.40.0"
 tokio = { version = "1.28.0", features = [
   "rt",
   "rt-multi-thread",
@@ -43,4 +44,3 @@ tokio = { version = "1.28.0", features = [
 ] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["json"] }
-insta = "1.40.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tracing-cloudwatch
 
-tracing-cloudwatch is a custom tracing-subscriber layer that sends your application's tracing events(logs) to AWS CloudWatch Logs.  
+tracing-cloudwatch is a custom tracing-subscriber layer that sends your application's tracing events(logs) to AWS CloudWatch Logs.
 
 We have supported [rusoto](https://github.com/rusoto/rusoto) and the [AWS SDK](https://github.com/awslabs/aws-sdk-rust) as AWS clients.
 
@@ -34,6 +34,12 @@ async fn main() {
         .init();
 }
 ```
+
+#### Chronological order
+
+When aggregating logs from multiple places (or integrations such as [tracing-gstreamer](https://crates.io/crates/tracing-gstreamer)), messages can become unordered. This causes a `InvalidParameterException: Log events in a single PutLogEvents request must be in chronological order.` error from the CloudWatch client. To mediate this, you may enable the `ordered_logs` feature. Take into consideration that this can possibly increase processing time significantly depending on the number of events in the batch. Your milage may vary!
+
+There is some additional context in https://github.com/ymgyt/tracing-cloudwatch/issues/40
 
 ### With Rusoto
 
@@ -84,7 +90,7 @@ tracing_subscriber::registry::Registry::default()
 
 Currently, following AWS IAM Permissions required
 
-* `logs:PutLogEvents`
+- `logs:PutLogEvents`
 
 ## CloudWatch Log Groups and Streams
 
@@ -94,7 +100,6 @@ This crate does not create a log group and log stream, so if the specified log g
 
 We haven't implemented any custom retry logic or timeout settings within the crate. We assume that these configurations are handled through the SDK Client.  
 For instance, in the AWS SDK, you can set up these configurations using [`timeout_config`](https://docs.rs/aws-sdk-cloudwatchlogs/0.28.0/aws_sdk_cloudwatchlogs/config/struct.Builder.html#method.timeout_config) and [`retry_config`](https://docs.rs/aws-sdk-cloudwatchlogs/0.28.0/aws_sdk_cloudwatchlogs/config/struct.Builder.html#method.retry_config)
-
 
 ## License
 


### PR DESCRIPTION
Fixes #40

The tests aren't great, but they work
```
# kayo @ ClockTower in ~/workspace/tracing-cloudwatch on git:ordering x [19:08:06] 
$ cargo test
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.05s
     Running unittests src/lib.rs (target/debug/deps/tracing_cloudwatch-420ac1eb2f0a2867)

running 3 tests
test export::tests::does_not_order_logs_by_default ... ok
test layer::tests::format ... ok
test layer::tests::with_fmt_layer_json ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

   Doc-tests tracing_cloudwatch

running 2 tests
test src/lib.rs - (line 11) ... ignored
test src/lib.rs - (line 37) ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s


# kayo @ ClockTower in ~/workspace/tracing-cloudwatch on git:ordering x [19:09:09] 
$ cargo test --features ordered_logs
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.05s
     Running unittests src/lib.rs (target/debug/deps/tracing_cloudwatch-b9d2b1e831be7a41)

running 3 tests
test export::tests::ordering::orders_logs_when_enabled ... ok
test layer::tests::format ... ok
test layer::tests::with_fmt_layer_json ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

   Doc-tests tracing_cloudwatch

running 2 tests
test src/lib.rs - (line 11) ... ignored
test src/lib.rs - (line 37) ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s
```