### PR TITLE
chore: use load_defaults() instead of load_from_env in awssdk example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() {
-    let config = aws_config::load_from_env().await;
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
     let cw_client = aws_sdk_cloudwatchlogs::Client::new(&config);
 
     tracing_subscriber::registry::Registry::default()

--- a/examples/awssdk.rs
+++ b/examples/awssdk.rs
@@ -1,9 +1,10 @@
 #[cfg(feature = "awssdk")]
 #[tokio::main]
 async fn main() {
+    use aws_config::BehaviorVersion;
     use std::time::Duration;
     use tracing_subscriber::{filter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
-    let config = aws_config::load_from_env().await;
+    let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
     let cw_client = aws_sdk_cloudwatchlogs::Client::new(&config);
 
     tracing_subscriber::registry::Registry::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let config = aws_config::load_from_env().await;
+//!     let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
 //!     let cw_client = aws_sdk_cloudwatchlogs::Client::new(&config);
 //!
 //!     tracing_subscriber::registry::Registry::default()


### PR DESCRIPTION
update aws sdk example