### PR TITLE
Remove type ambiguity of `batch_size` export.rs

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -127,7 +127,7 @@ where
                     };
 
                     queue.push(event);
-                    if queue.len() < config.batch_size.into() {
+                    if queue.len() < <NonZero<usize> as Into<usize>>::into(config.batch_size) {
                         continue
                     }
                 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -127,7 +127,7 @@ where
                     };
 
                     queue.push(event);
-                    if queue.len() < <NonZero<usize> as Into<usize>>::into(config.batch_size) {
+                    if queue.len() < <NonZeroUsize as Into<usize>>::into(config.batch_size) {
                         continue
                     }
                 }


### PR DESCRIPTION
Due to a conflicting implementation of `PartialOrd` in `deranged 0.4.1` which is a transitive dependency of `aws-config`, type inference in `usize < NonZeroUsize` no longer works.

The maintainer of `deranged` has [indicated that he wont be reverting this change](https://github.com/jhpratt/deranged/issues/18#issuecomment-2749704917) and downstream libs need to be updated to resolve the issue.

Conflicting impls:

**deranged 0.4.1**
```Rust
impl<MIN, MAX> PartialOrd<deranged::RangedUsize<MIN, MAX>> for usize
```

**core**
```Rust
impl PartialOrd for usize
```

This issue is only present with feature `awssdk` enabled.

Error:
```
error[E0283]: type annotations needed
   --> src/export.rs:130:56
    |
130 |                     if queue.len() < config.batch_size.into() {
    |                                    -                   ^^^^
    |                                    |
    |                                    type must be known at this point
    |
    = note: multiple `impl`s satisfying `usize: PartialOrd<_>` found in the following crates: `core`, `deranged`:
            - impl PartialOrd for usize;
            - impl<MIN, MAX> PartialOrd<deranged::RangedUsize<MIN, MAX>> for usize
              where the constant `MIN` has type `usize`, the constant `MAX` has type `usize`;
help: try using a fully qualified path to specify the expected types
    |
130 |                     if queue.len() < <NonZero<usize> as Into<T>>::into(config.batch_size) {
    |                                      ++++++++++++++++++++++++++++++++++                 ~

For more information about this error, try `rustc --explain E0283`.
error: could not compile `tracing-cloudwatch` (lib) due to 1 previous error
```