### PR TITLE
fix: Expose dispatcher types 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//!  tracing-cloudwatch is a custom tracing-subscriber layer that sends your application's tracing events(logs) to AWS CloudWatch Logs.  
+//!  tracing-cloudwatch is a custom tracing-subscriber layer that sends your application's tracing events(logs) to AWS CloudWatch Logs.
 //!
 //! We have supported [rusoto](https://github.com/rusoto/rusoto) and the [AWS SDK](https://github.com/awslabs/aws-sdk-rust) as AWS clients.
 //!
@@ -78,6 +78,6 @@ mod export;
 mod layer;
 
 pub use client::CloudWatchClient;
-pub use dispatch::{CloudWatchDispatcher, Dispatcher, NoopDispatcher};
+pub use dispatch::{CloudWatchDispatcher, NoopDispatcher};
 pub use export::{ExportConfig, LogDestination};
 pub use layer::{layer, CloudWatchLayer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,5 +78,6 @@ mod export;
 mod layer;
 
 pub use client::CloudWatchClient;
+pub use dispatch::{CloudWatchDispatcher, Dispatcher, NoopDispatcher};
 pub use export::{ExportConfig, LogDestination};
 pub use layer::{layer, CloudWatchLayer};


### PR DESCRIPTION
## Description

Exports the dispatcher types used as part of the CloudWatchLayer so that consumers of the API can write out all the required generics when returning it from a function.

Currently the following is not possible because we are not able to specify the `CloudWatchDispatcher` type for the  `CloudWatchLayer` generic paramters:

```rust
pub fn cloudwatch_layer<S>(
    aws_config: &SdkConfig,
    config: CloudwatchLoggingConfig,
) -> CloudWatchLayer<S,  /* Not able to type this generic */>
where
    S: Subscriber + for<'a> LookupSpan<'a>,
{
    let cw_client = aws_sdk_cloudwatchlogs::Client::new(&aws_config);

    tracing_cloudwatch::layer().with_client(
        cw_client,
        tracing_cloudwatch::ExportConfig::default()
            .with_batch_size(5)
            .with_interval(std::time::Duration::from_secs(1))
            .with_log_group_name("tracing-cloudwatch")
            .with_log_stream_name("stream-1"),
    )
}
```

This instead has to be typed as:

```rust
pub fn cloudwatch_layer<S>(
    aws_config: &SdkConfig,
    config: CloudwatchLoggingConfig,
) -> impl Layer<S>
where
    S: Subscriber + for<'a> LookupSpan<'a>,
{
    let cw_client = aws_sdk_cloudwatchlogs::Client::new(&aws_config);

    tracing_cloudwatch::layer().with_client(
        cw_client,
        tracing_cloudwatch::ExportConfig::default()
            .with_batch_size(5)
            .with_interval(std::time::Duration::from_secs(1))
            .with_log_group_name("tracing-cloudwatch")
            .with_log_stream_name("stream-1"),
    )
}
```

This fixes that by making the  `CloudWatchDispatcher` type available to consumers of the crate 

```rust
pub fn cloudwatch_layer<S>(
    aws_config: &SdkConfig,
    config: CloudwatchLoggingConfig,
) -> CloudWatchLayer<S, CloudWatchDispatcher>
where
    S: Subscriber + for<'a> LookupSpan<'a>,
{
    let cw_client = aws_sdk_cloudwatchlogs::Client::new(&aws_config);

    tracing_cloudwatch::layer().with_client(
        cw_client,
        tracing_cloudwatch::ExportConfig::default()
            .with_batch_size(5)
            .with_interval(std::time::Duration::from_secs(1))
            .with_log_group_name("tracing-cloudwatch")
            .with_log_stream_name("stream-1"),
    )
}
```

## Changes

- Re-exports the dispatch types (CloudWatchDispatcher, Dispatcher, and NoopDispatcher)