### PR TITLE
feat: shutdown guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,20 @@ async fn main() {
     let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
     let cw_client = aws_sdk_cloudwatchlogs::Client::new(&config);
 
+    let (cw_layer, _cw_guard) = tracing_cloudwatch::layer()
+        .with_code_location(true)
+        .with_target(false)
+        .with_client(
+            cw_client,
+            tracing_cloudwatch::ExportConfig::default()
+                .with_batch_size(5)
+                .with_interval(std::time::Duration::from_secs(1))
+                .with_log_group_name("tracing-cloudwatch")
+                .with_log_stream_name("stream-1"),
+        );
+
     tracing_subscriber::registry::Registry::default()
-        .with(
-            tracing_cloudwatch::layer().with_client(
-                cw_client,
-                tracing_cloudwatch::ExportConfig::default()
-                    .with_batch_size(5)
-                    .with_interval(std::time::Duration::from_secs(1))
-                    .with_log_group_name("tracing-cloudwatch")
-                    .with_log_stream_name("stream-1"),
-            )
-            .with_code_location(true)
-            .with_target(false),
-        )
+        .with(cw_layer)
         .init();
 }
 ```
@@ -52,19 +53,20 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() {
     let cw_client = rusoto_logs::CloudWatchLogsClient::new(rusoto_core::Region::ApNortheast1);
 
+    let (cw_layer, _cw_guard) = tracing_cloudwatch::layer()
+        .with_code_location(true)
+        .with_target(false)
+        .with_client(
+            cw_client,
+            tracing_cloudwatch::ExportConfig::default()
+                .with_batch_size(5)
+                .with_interval(std::time::Duration::from_secs(1))
+                .with_log_group_name("tracing-cloudwatch")
+                .with_log_stream_name("stream-1"),
+        );
+
     tracing_subscriber::registry::Registry::default()
-        .with(
-            tracing_cloudwatch::layer().with_client(
-                cw_client,
-                tracing_cloudwatch::ExportConfig::default()
-                    .with_batch_size(5)
-                    .with_interval(std::time::Duration::from_secs(1))
-                    .with_log_group_name("tracing-cloudwatch")
-                    .with_log_stream_name("stream-1"),
-            )
-            .with_code_location(true)
-            .with_target(false),
-        )
+        .with(cw_layer)
         .init();
 }
 ```

--- a/examples/awssdk.rs
+++ b/examples/awssdk.rs
@@ -7,22 +7,22 @@ async fn main() {
     let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
     let cw_client = aws_sdk_cloudwatchlogs::Client::new(&config);
 
+    let (cw_layer, _cw_guard) = tracing_cloudwatch::layer()
+        .with_client(
+            cw_client,
+            tracing_cloudwatch::ExportConfig::default()
+                .with_batch_size(1)
+                .with_interval(Duration::from_secs(1))
+                .with_log_group_name("tracing-cloudwatch")
+                .with_log_stream_name("stream-1"),
+        )
+        .with_code_location(true)
+        .with_target(false);
+
     tracing_subscriber::registry::Registry::default()
         .with(fmt::layer().with_ansi(true))
         .with(filter::LevelFilter::INFO)
-        .with(
-            tracing_cloudwatch::layer()
-                .with_client(
-                    cw_client,
-                    tracing_cloudwatch::ExportConfig::default()
-                        .with_batch_size(1)
-                        .with_interval(Duration::from_secs(1))
-                        .with_log_group_name("tracing-cloudwatch")
-                        .with_log_stream_name("stream-1"),
-                )
-                .with_code_location(true)
-                .with_target(false),
-        )
+        .with(cw_layer)
         .init();
 
     start().await;

--- a/examples/awssdk.rs
+++ b/examples/awssdk.rs
@@ -8,6 +8,8 @@ async fn main() {
     let cw_client = aws_sdk_cloudwatchlogs::Client::new(&config);
 
     let (cw_layer, _cw_guard) = tracing_cloudwatch::layer()
+        .with_code_location(true)
+        .with_target(false)
         .with_client(
             cw_client,
             tracing_cloudwatch::ExportConfig::default()
@@ -15,9 +17,7 @@ async fn main() {
                 .with_interval(Duration::from_secs(1))
                 .with_log_group_name("tracing-cloudwatch")
                 .with_log_stream_name("stream-1"),
-        )
-        .with_code_location(true)
-        .with_target(false);
+        );
 
     tracing_subscriber::registry::Registry::default()
         .with(fmt::layer().with_ansi(true))

--- a/examples/rusoto.rs
+++ b/examples/rusoto.rs
@@ -6,19 +6,19 @@ async fn main() {
     use tracing_subscriber::{filter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
     let cw_client = rusoto_logs::CloudWatchLogsClient::new(Region::ApNortheast1);
 
+    let (cw_layer, _cw_guard) = tracing_cloudwatch::layer().with_client(
+        cw_client,
+        tracing_cloudwatch::ExportConfig::default()
+            .with_batch_size(1)
+            .with_interval(Duration::from_secs(1))
+            .with_log_group_name("tracing-cloudwatch")
+            .with_log_stream_name("stream-1"),
+    );
+
     tracing_subscriber::registry::Registry::default()
         .with(fmt::layer().with_ansi(true))
         .with(filter::LevelFilter::INFO)
-        .with(
-            tracing_cloudwatch::layer().with_client(
-                cw_client,
-                tracing_cloudwatch::ExportConfig::default()
-                    .with_batch_size(1)
-                    .with_interval(Duration::from_secs(1))
-                    .with_log_group_name("tracing-cloudwatch")
-                    .with_log_stream_name("stream-1"),
-            ),
-        )
+        .with(cw_layer)
         .init();
 
     start().await;

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -4,7 +4,10 @@ use crate::{
 };
 
 use chrono::{DateTime, Utc};
-use tokio::sync::mpsc::{self, Receiver, UnboundedSender};
+use tokio::sync::{
+    mpsc::{self, UnboundedSender},
+    oneshot,
+};
 
 pub trait Dispatcher {
     fn dispatch(&self, input: LogEvent);
@@ -33,7 +36,11 @@ pub struct CloudWatchDispatcher {
 }
 
 impl CloudWatchDispatcher {
-    pub(crate) fn new<C>(client: C, export_config: ExportConfig, shutdown_rx: Receiver<()>) -> Self
+    pub(crate) fn new<C>(
+        client: C,
+        export_config: ExportConfig,
+        shutdown_rx: oneshot::Receiver<()>,
+    ) -> Self
     where
         C: CloudWatchClient + Send + Sync + 'static,
     {

--- a/src/export.rs
+++ b/src/export.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use tokio::{
-    sync::mpsc::{Receiver, UnboundedReceiver},
+    sync::{mpsc::UnboundedReceiver, oneshot},
     time::interval,
 };
 
@@ -111,7 +111,7 @@ where
     pub(crate) async fn run(
         mut self,
         mut rx: UnboundedReceiver<LogEvent>,
-        mut shutdown_rx: Receiver<()>,
+        mut shutdown_rx: oneshot::Receiver<()>,
     ) {
         let mut interval = interval(self.config.interval);
 
@@ -133,7 +133,7 @@ where
                     }
                 }
 
-                _ = shutdown_rx.recv() => {
+                _ = &mut shutdown_rx => {
                     self.flush().await;
                     break;
                 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -2,7 +2,10 @@ use std::fmt::Debug;
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
-use tokio::{sync::mpsc::UnboundedReceiver, time::interval};
+use tokio::{
+    sync::mpsc::{Receiver, UnboundedReceiver},
+    time::interval,
+};
 
 use crate::{client::NoopClient, dispatch::LogEvent, CloudWatchClient};
 
@@ -105,19 +108,17 @@ impl<C> BatchExporter<C>
 where
     C: CloudWatchClient + Send + Sync + 'static,
 {
-    pub(crate) async fn run(self, mut rx: UnboundedReceiver<LogEvent>) {
-        let BatchExporter {
-            client,
-            mut queue,
-            config,
-        } = self;
-
-        let mut interval = interval(config.interval);
+    pub(crate) async fn run(
+        mut self,
+        mut rx: UnboundedReceiver<LogEvent>,
+        mut shutdown_rx: Receiver<()>,
+    ) {
+        let mut interval = interval(self.config.interval);
 
         loop {
             tokio::select! {
                  _ = interval.tick() => {
-                    if queue.is_empty() {
+                    if self.queue.is_empty() {
                         continue;
                     }
                 }
@@ -126,21 +127,38 @@ where
                         break;
                     };
 
-                    queue.push(event);
-                    if queue.len() < <NonZeroUsize as Into<usize>>::into(config.batch_size) {
+                    self.queue.push(event);
+                    if self.queue.len() < <NonZeroUsize as Into<usize>>::into(self.config.batch_size) {
                         continue
                     }
                 }
+
+                _ = shutdown_rx.recv() => {
+                    self.flush().await;
+                    break;
+                }
             }
 
-            let logs: Vec<LogEvent> = Self::take_from_queue(&mut queue);
+            self.flush().await;
+        }
+    }
 
-            if let Err(err) = client.put_logs(config.destination.clone(), logs).await {
-                eprintln!(
-                    "[tracing-cloudwatch] Unable to put logs to cloudwatch. Error: {err:?} {:?}",
-                    config.destination
-                );
-            }
+    async fn flush(&mut self) {
+        let logs: Vec<LogEvent> = Self::take_from_queue(&mut self.queue);
+
+        if logs.is_empty() {
+            return;
+        }
+
+        if let Err(err) = self
+            .client
+            .put_logs(self.config.destination.clone(), logs)
+            .await
+        {
+            eprintln!(
+                "[tracing-cloudwatch] Unable to put logs to cloudwatch. Error: {err:?} {:?}",
+                self.config.destination
+            );
         }
     }
 

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -33,7 +33,7 @@ impl Drop for CloudWatchWorkerGuard {
         ) {
             Ok(_) => {}
             Err(SendTimeoutError::Closed(_)) => (),
-            Err(SendTimeoutError::Timeout(e)) => println!(
+            Err(SendTimeoutError::Timeout(e)) => eprintln!(
                 "Failed to send shutdown signal to logging worker. Error: {:?}",
                 e
             ),

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -5,6 +5,14 @@ use tokio::{
     sync::mpsc::{error::SendTimeoutError, Sender},
 };
 
+/// Guard returned when creating a CloudWatch layer
+///
+/// When this guard is dropped a shutdown signal will be
+/// sent to the CloudWatch logging worker to flush logs and
+/// stop processing any more logs.
+///
+/// This is used to ensure buffered logs are flushed on panic
+/// or graceful shutdown.
 pub struct CloudWatchWorkerGuard {
     shutdown_tx: Sender<()>,
 }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use tokio::{
+    runtime::Handle,
+    sync::mpsc::{error::SendTimeoutError, Sender},
+};
+
+pub struct CloudWatchWorkerGuard {
+    shutdown_tx: Sender<()>,
+}
+
+impl CloudWatchWorkerGuard {
+    pub(crate) fn new(shutdown_tx: Sender<()>) -> Self {
+        Self { shutdown_tx }
+    }
+}
+
+impl Drop for CloudWatchWorkerGuard {
+    fn drop(&mut self) {
+        let handle = Handle::current();
+
+        match handle.block_on(
+            self.shutdown_tx
+                .send_timeout((), Duration::from_millis(1000)),
+        ) {
+            Ok(_) => {}
+            Err(SendTimeoutError::Closed(_)) => (),
+            Err(SendTimeoutError::Timeout(e)) => println!(
+                "Failed to send shutdown signal to logging worker. Error: {:?}",
+                e
+            ),
+        }
+    }
+}

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -97,7 +97,7 @@ where
     where
         Client: CloudWatchClient + Send + Sync + 'static,
     {
-        let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel(1);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
         let guard = CloudWatchWorkerGuard::new(shutdown_tx);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//!  tracing-cloudwatch is a custom tracing-subscriber layer that sends your application's tracing events(logs) to AWS CloudWatch Logs.  
+//!  tracing-cloudwatch is a custom tracing-subscriber layer that sends your application's tracing events(logs) to AWS CloudWatch Logs.
 //!
 //! We have supported [rusoto](https://github.com/rusoto/rusoto) and the [AWS SDK](https://github.com/awslabs/aws-sdk-rust) as AWS clients.
 //!
@@ -15,17 +15,17 @@
 //! async fn main() {
 //!     let cw_client = rusoto_logs::CloudWatchLogsClient::new(rusoto_core::Region::ApNortheast1);
 //!
+//!     let (cw_layer, _cw_guard) = tracing_cloudwatch::layer().with_client(
+//!         cw_client,
+//!         tracing_cloudwatch::ExportConfig::default()
+//!             .with_batch_size(5)
+//!             .with_interval(std::time::Duration::from_secs(1))
+//!             .with_log_group_name("tracing-cloudwatch")
+//!             .with_log_stream_name("stream-1"),
+//!     );
+//!
 //!     tracing_subscriber::registry::Registry::default()
-//!         .with(
-//!             tracing_cloudwatch::layer().with_client(
-//!                 cw_client,
-//!                 tracing_cloudwatch::ExportConfig::default()
-//!                     .with_batch_size(5)
-//!                     .with_interval(std::time::Duration::from_secs(1))
-//!                     .with_log_group_name("tracing-cloudwatch")
-//!                     .with_log_stream_name("stream-1"),
-//!             ),
-//!         )
+//!         .with(cw_layer)
 //!         .init();
 //! }
 //! ```
@@ -42,17 +42,17 @@
 //!     let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
 //!     let cw_client = aws_sdk_cloudwatchlogs::Client::new(&config);
 //!
+//!     let (cw_layer, _cw_guard) = tracing_cloudwatch::layer().with_client(
+//!         cw_client,
+//!         tracing_cloudwatch::ExportConfig::default()
+//!             .with_batch_size(5)
+//!             .with_interval(std::time::Duration::from_secs(1))
+//!             .with_log_group_name("tracing-cloudwatch")
+//!             .with_log_stream_name("stream-1"),
+//!     );
+//!
 //!     tracing_subscriber::registry::Registry::default()
-//!         .with(
-//!             tracing_cloudwatch::layer().with_client(
-//!                 cw_client,
-//!                 tracing_cloudwatch::ExportConfig::default()
-//!                     .with_batch_size(5)
-//!                     .with_interval(std::time::Duration::from_secs(1))
-//!                     .with_log_group_name("tracing-cloudwatch")
-//!                     .with_log_stream_name("stream-1"),
-//!             ),
-//!         )
+//!         .with(cw_layer)
 //!         .init();
 //! }
 //! ```
@@ -75,8 +75,10 @@
 mod client;
 mod dispatch;
 mod export;
+mod guard;
 mod layer;
 
 pub use client::CloudWatchClient;
 pub use export::{ExportConfig, LogDestination};
+pub use guard::CloudWatchWorkerGuard;
 pub use layer::{layer, CloudWatchLayer};


### PR DESCRIPTION
## Description

Add a guard like other async loggers to trigger a flush when the guard is dropped. This is a breaking change which makes with_client return a tuple of both the layer and the guard.

On drop the guard will send a signal to the worker telling it to stop processing more logs and to flush the current logs queue.

## Changes

- with_client now also returns a CloudWatchWorkerGuard
- Added a shutdown single message channel
- Moved "flushing" put_logs code inta a "flush" function since the same logic is used for regular flushing and the shutdown flush
- Updated examples and other related documentation

## Related Issues

- Closes #16 