### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -15,7 +15,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/create-gh-release-action@v1
         with:
           changelog: CHANGELOG.md
@@ -28,11 +28,9 @@ jobs:
   publish-cratesio:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          # cargo is enough
           profile: minimal
       - name: Setup local credential
         run: cargo login ${CRATES_IO_TOKEN}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,33 +3,20 @@ on:
   pull_request:
     types: ["opened", "synchronize"]
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   check:
     name: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+    - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@stable
-    - uses: davidB/rust-cargo-make@v1
-    - uses: actions-rs/install@master
+    - uses: Swatinem/rust-cache@v2
+    - uses: taiki-e/install-action@v2
       with:
-        crate: cargo-sort
-        use-tool-cache: true
-    - uses: actions-rs/install@master
-      with:
-        crate: cargo-nextest
-        use-tool-cache: true
+        tool: cargo-make,cargo-sort,cargo-nextest
     - run: cargo make lint
     - run: cargo make test
-    


### PR DESCRIPTION
Fixes: https://github.com/ymgyt/tracing-cloudwatch/actions/runs/22515168173

- Replace custom cargo caching with Swatinem/rust-cache@v2.
- Standardize Rust CLI tool installation via taiki-e/install-action@v2 (cargo-make, cargo-sort, nextest).
- Add explicit minimal CI permissions (contents: read).
- Switch CD toolchain setup to dtolnay/rust-toolchain@stable.
