### PR TITLE
feat: add CloudWatchWorkerGuard::shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ async fn main() {
     let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
     let cw_client = aws_sdk_cloudwatchlogs::Client::new(&config);
 
-    let (cw_layer, _cw_guard) = tracing_cloudwatch::layer()
+    let (cw_layer, cw_guard) = tracing_cloudwatch::layer()
         .with_code_location(true)
         .with_target(false)
         .with_client(
@@ -33,6 +33,8 @@ async fn main() {
     tracing_subscriber::registry::Registry::default()
         .with(cw_layer)
         .init();
+
+    cw_guard.shutdown().await;
 }
 ```
 
@@ -53,7 +55,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() {
     let cw_client = rusoto_logs::CloudWatchLogsClient::new(rusoto_core::Region::ApNortheast1);
 
-    let (cw_layer, _cw_guard) = tracing_cloudwatch::layer()
+    let (cw_layer, cw_guard) = tracing_cloudwatch::layer()
         .with_code_location(true)
         .with_target(false)
         .with_client(
@@ -68,6 +70,8 @@ async fn main() {
     tracing_subscriber::registry::Registry::default()
         .with(cw_layer)
         .init();
+
+    cw_guard.shutdown().await;
 }
 ```
 

--- a/examples/awssdk.rs
+++ b/examples/awssdk.rs
@@ -7,7 +7,7 @@ async fn main() {
     let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
     let cw_client = aws_sdk_cloudwatchlogs::Client::new(&config);
 
-    let (cw_layer, _cw_guard) = tracing_cloudwatch::layer()
+    let (cw_layer, cw_guard) = tracing_cloudwatch::layer()
         .with_code_location(true)
         .with_target(false)
         .with_client(
@@ -28,11 +28,13 @@ async fn main() {
     start().await;
 
     tokio::time::sleep(Duration::from_secs(10)).await;
+    cw_guard.shutdown().await;
 }
 
 #[cfg(not(feature = "awssdk"))]
 fn main() {}
 
+#[cfg(feature = "awssdk")]
 #[tracing::instrument()]
 async fn start() {
     tracing::info!("Starting...");

--- a/examples/rusoto.rs
+++ b/examples/rusoto.rs
@@ -6,7 +6,7 @@ async fn main() {
     use tracing_subscriber::{filter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
     let cw_client = rusoto_logs::CloudWatchLogsClient::new(Region::ApNortheast1);
 
-    let (cw_layer, _cw_guard) = tracing_cloudwatch::layer().with_client(
+    let (cw_layer, cw_guard) = tracing_cloudwatch::layer().with_client(
         cw_client,
         tracing_cloudwatch::ExportConfig::default()
             .with_batch_size(1)
@@ -24,11 +24,13 @@ async fn main() {
     start().await;
 
     tokio::time::sleep(Duration::from_secs(5)).await;
+    cw_guard.shutdown().await;
 }
 
 #[cfg(all(not(feature = "rusoto"), not(feature = "rusoto_rustls")))]
 fn main() {}
 
+#[cfg(any(feature = "rusoto", feature = "rusoto_rustls"))]
 #[tracing::instrument()]
 async fn start() {
     tracing::info!("Starting...");

--- a/src/export.rs
+++ b/src/export.rs
@@ -7,7 +7,7 @@ use tokio::{
     time::interval,
 };
 
-use crate::{client::NoopClient, dispatch::LogEvent, CloudWatchClient};
+use crate::{client::NoopClient, dispatch::LogEvent, guard::ShutdownSignal, CloudWatchClient};
 
 /// Configurations to control the behavior of exporting logs to CloudWatch.
 #[derive(Debug, Clone)]
@@ -111,9 +111,10 @@ where
     pub(crate) async fn run(
         mut self,
         mut rx: UnboundedReceiver<LogEvent>,
-        mut shutdown_rx: oneshot::Receiver<()>,
+        mut shutdown_rx: oneshot::Receiver<ShutdownSignal>,
     ) {
         let mut interval = interval(self.config.interval);
+        let mut shutdown_signal = None;
 
         loop {
             tokio::select! {
@@ -122,6 +123,7 @@ where
                         continue;
                     }
                 }
+
                 event = rx.recv() => {
                     let Some(event) = event else {
                         break;
@@ -133,13 +135,21 @@ where
                     }
                 }
 
-                _ = &mut shutdown_rx => {
-                    self.flush().await;
+                received_shutdown = &mut shutdown_rx => {
+                    if let Ok(signal) = received_shutdown {
+                        shutdown_signal = Some(signal);
+                    }
+                    while let Ok(event) = rx.try_recv() {
+                        self.queue.push(event);
+                    }
                     break;
                 }
             }
-
             self.flush().await;
+        }
+        self.flush().await;
+        if let Some(shutdown_signal) = shutdown_signal {
+            shutdown_signal.ack();
         }
     }
 
@@ -176,7 +186,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
     use chrono::{DateTime, Utc};
+    use std::sync::{Arc, Mutex};
+    use tokio::time::{sleep, timeout};
+    use tracing_subscriber::layer::SubscriberExt;
 
     const ONE_DAY_NS: i64 = 86_400_000_000_000;
     const DAY_ONE: DateTime<Utc> = DateTime::from_timestamp_nanos(0 + ONE_DAY_NS);
@@ -255,5 +269,174 @@ mod tests {
             let ordered_queue = BatchExporter::<NoopClient>::take_from_queue(&mut unordered_queue);
             assert_is_ordered(ordered_queue);
         }
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingClient {
+        logs: Arc<Mutex<Vec<LogEvent>>>,
+    }
+
+    #[async_trait]
+    impl CloudWatchClient for RecordingClient {
+        async fn put_logs(
+            &self,
+            _dest: LogDestination,
+            logs: Vec<LogEvent>,
+        ) -> Result<(), crate::client::PutLogsError> {
+            self.logs.lock().unwrap().extend(logs);
+            Ok(())
+        }
+    }
+
+    impl RecordingClient {
+        fn exported_count(&self) -> usize {
+            self.logs.lock().unwrap().len()
+        }
+
+        fn exported_messages(&self) -> Vec<String> {
+            self.logs
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|event| event.message.clone())
+                .collect()
+        }
+    }
+
+    async fn wait_for_exported_count(client: &RecordingClient, expected: usize) {
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if client.exported_count() >= expected {
+                    break;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for exported log events");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn drains_all_buffered_events_on_shutdown() {
+        let client = RecordingClient::default();
+        let exporter = BatchExporter::new(
+            client.clone(),
+            ExportConfig::default()
+                .with_batch_size(10_000)
+                .with_interval(Duration::from_secs(60))
+                .with_log_group_name("group")
+                .with_log_stream_name("stream"),
+        );
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<ShutdownSignal>();
+        let (shutdown_signal, _ack_rx) = ShutdownSignal::new();
+
+        let total = 512;
+        for idx in 0..total {
+            tx.send(LogEvent {
+                message: format!("event-{idx}"),
+                timestamp: Utc::now(),
+            })
+            .unwrap();
+        }
+        drop(tx);
+        shutdown_tx.send(shutdown_signal).unwrap();
+
+        exporter.run(rx, shutdown_rx).await;
+
+        assert_eq!(
+            client.exported_count(),
+            total,
+            "all events queued before shutdown should be exported"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn exports_events_with_registry_on_guard_shutdown() {
+        let client = RecordingClient::default();
+        let (cw_layer, guard) = crate::layer()
+            .with_code_location(false)
+            .with_target(false)
+            .with_client(
+                client.clone(),
+                ExportConfig::default()
+                    .with_batch_size(1024)
+                    .with_interval(Duration::from_secs(60))
+                    .with_log_group_name("group")
+                    .with_log_stream_name("stream"),
+            );
+
+        let subscriber = tracing_subscriber::registry().with(cw_layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("integration-log-1");
+            tracing::warn!("integration-log-2");
+        });
+
+        guard.shutdown().await;
+
+        let messages = client.exported_messages();
+        assert_eq!(messages.len(), 2);
+        assert!(messages
+            .iter()
+            .any(|message| message.contains("integration-log-1")));
+        assert!(messages
+            .iter()
+            .any(|message| message.contains("integration-log-2")));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn exports_when_batch_size_is_reached() {
+        let client = RecordingClient::default();
+        let (cw_layer, guard) = crate::layer()
+            .with_code_location(false)
+            .with_target(false)
+            .with_client(
+                client.clone(),
+                ExportConfig::default()
+                    .with_batch_size(2)
+                    .with_interval(Duration::from_secs(60))
+                    .with_log_group_name("group")
+                    .with_log_stream_name("stream"),
+            );
+
+        let subscriber = tracing_subscriber::registry().with(cw_layer);
+        // Let the exporter consume the initial immediate interval tick while the queue is empty.
+        sleep(Duration::from_millis(20)).await;
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("batch-log-1");
+            tracing::info!("batch-log-2");
+        });
+
+        wait_for_exported_count(&client, 2).await;
+        guard.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn exports_without_shutdown_when_batch_not_full() {
+        let client = RecordingClient::default();
+        let (cw_layer, guard) = crate::layer()
+            .with_code_location(false)
+            .with_target(false)
+            .with_client(
+                client.clone(),
+                ExportConfig::default()
+                    .with_batch_size(1024)
+                    .with_interval(Duration::from_millis(200))
+                    .with_log_group_name("group")
+                    .with_log_stream_name("stream"),
+            );
+
+        let subscriber = tracing_subscriber::registry().with(cw_layer);
+        // Let the exporter consume the initial immediate interval tick while the queue is empty.
+        sleep(Duration::from_millis(20)).await;
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("interval-log-1");
+        });
+
+        wait_for_exported_count(&client, 1).await;
+        guard.shutdown().await;
     }
 }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,5 +1,21 @@
 use tokio::sync::oneshot;
 
+#[derive(Debug)]
+pub(crate) struct ShutdownSignal {
+    ack_tx: oneshot::Sender<()>,
+}
+
+impl ShutdownSignal {
+    pub(crate) fn new() -> (Self, oneshot::Receiver<()>) {
+        let (ack_tx, ack_rx) = oneshot::channel();
+        (Self { ack_tx }, ack_rx)
+    }
+
+    pub(crate) fn ack(self) {
+        let _ = self.ack_tx.send(());
+    }
+}
+
 /// Guard returned when creating a CloudWatch layer
 ///
 /// When this guard is dropped a shutdown signal will be
@@ -7,26 +23,70 @@ use tokio::sync::oneshot;
 /// stop processing any more logs.
 ///
 /// This is used to ensure buffered logs are flushed on panic
-/// or graceful shutdown.
+/// or graceful shutdown. Use [`CloudWatchWorkerGuard::shutdown`]
+/// to explicitly wait for completion.
 pub struct CloudWatchWorkerGuard {
-    shutdown_tx: Option<oneshot::Sender<()>>,
+    shutdown_tx: Option<oneshot::Sender<ShutdownSignal>>,
 }
 
 impl CloudWatchWorkerGuard {
-    pub(crate) fn new(shutdown_tx: oneshot::Sender<()>) -> Self {
+    pub(crate) fn new(shutdown_tx: oneshot::Sender<ShutdownSignal>) -> Self {
         Self {
             shutdown_tx: Some(shutdown_tx),
         }
+    }
+
+    fn take_shutdown_tx(&mut self) -> Option<oneshot::Sender<ShutdownSignal>> {
+        self.shutdown_tx.take()
+    }
+
+    /// Trigger a graceful shutdown and wait for the worker to finish
+    /// draining and flushing queued logs.
+    pub async fn shutdown(mut self) {
+        let shutdown_tx = match self.take_shutdown_tx() {
+            Some(value) => value,
+            None => return,
+        };
+
+        let (shutdown_signal, ack_rx) = ShutdownSignal::new();
+
+        if shutdown_tx.send(shutdown_signal).is_err() {
+            return;
+        }
+
+        _ = ack_rx.await;
     }
 }
 
 impl Drop for CloudWatchWorkerGuard {
     fn drop(&mut self) {
-        let shutdown_tx = match self.shutdown_tx.take() {
+        let shutdown_tx = match self.take_shutdown_tx() {
             Some(value) => value,
             None => return,
         };
 
-        _ = shutdown_tx.send(());
+        let (shutdown_signal, _ack_rx) = ShutdownSignal::new();
+        let _ = shutdown_tx.send(shutdown_signal);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::{sleep, Duration};
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_waits_for_ack() {
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<ShutdownSignal>();
+        let guard = CloudWatchWorkerGuard::new(shutdown_tx);
+
+        let worker = tokio::spawn(async move {
+            let signal = shutdown_rx.await.unwrap();
+            sleep(Duration::from_millis(20)).await;
+            signal.ack();
+        });
+
+        guard.shutdown().await;
+        worker.await.unwrap();
     }
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -12,7 +12,7 @@ use crate::{
     client::CloudWatchClient,
     dispatch::{CloudWatchDispatcher, Dispatcher, NoopDispatcher},
     export::ExportConfig,
-    guard::CloudWatchWorkerGuard,
+    guard::{CloudWatchWorkerGuard, ShutdownSignal},
 };
 
 /// An AWS Cloudwatch propagation layer.
@@ -97,7 +97,7 @@ where
     where
         Client: CloudWatchClient + Send + Sync + 'static,
     {
-        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<ShutdownSignal>();
 
         let guard = CloudWatchWorkerGuard::new(shutdown_tx);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! async fn main() {
 //!     let cw_client = rusoto_logs::CloudWatchLogsClient::new(rusoto_core::Region::ApNortheast1);
 //!
-//!     let (cw_layer, _cw_guard) = tracing_cloudwatch::layer().with_client(
+//!     let (cw_layer, cw_guard) = tracing_cloudwatch::layer().with_client(
 //!         cw_client,
 //!         tracing_cloudwatch::ExportConfig::default()
 //!             .with_batch_size(5)
@@ -27,6 +27,8 @@
 //!     tracing_subscriber::registry::Registry::default()
 //!         .with(cw_layer)
 //!         .init();
+//!
+//!     cw_guard.shutdown().await;
 //! }
 //! ```
 //!
@@ -42,7 +44,7 @@
 //!     let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
 //!     let cw_client = aws_sdk_cloudwatchlogs::Client::new(&config);
 //!
-//!     let (cw_layer, _cw_guard) = tracing_cloudwatch::layer().with_client(
+//!     let (cw_layer, cw_guard) = tracing_cloudwatch::layer().with_client(
 //!         cw_client,
 //!         tracing_cloudwatch::ExportConfig::default()
 //!             .with_batch_size(5)
@@ -54,6 +56,8 @@
 //!     tracing_subscriber::registry::Registry::default()
 //!         .with(cw_layer)
 //!         .init();
+//!
+//!     cw_guard.shutdown().await;
 //! }
 //! ```
 //!


### PR DESCRIPTION
follow up https://github.com/ymgyt/tracing-cloudwatch/pull/52#pullrequestreview-3870433570

This adds an explicit `CloudWatchWorkerGuard::shutdown()` API so applications can
  intentionally wait until the exporter finishes flushing. Internally, shutdown now uses an acked signal: when shutdown is requested, the exporter drains any remaining events from the channel, performs a final flush, and only then acknowledges completion. 

The `Drop` path stays best-effort (signal only) so we don’t block in destructors.
I also removed the panic on late dispatch after shutdown.
